### PR TITLE
Added Reflection to gather IChatMessage classes for DI

### DIFF
--- a/AmazingTwitchBot.Agent/Program.cs
+++ b/AmazingTwitchBot.Agent/Program.cs
@@ -2,16 +2,12 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 
 
 using AmazingTwitchBot.Agent.Models.Configuration;
-using System.Collections.Generic;
 using AmazingTwitchBot.Agent.Rules;
-using AmazingTwitchBot.Agent.Rules.ChatCommands;
 using System.Reflection;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 
 namespace AmazingTwitchBot.Agent
 {

--- a/AmazingTwitchBot.Agent/Program.cs
+++ b/AmazingTwitchBot.Agent/Program.cs
@@ -33,8 +33,7 @@ namespace AmazingTwitchBot.Agent
 				.GetTypes()
 				.Where(x => x.Namespace == "AmazingTwitchBot.Agent.Rules.ChatCommands")
 				.Where(x => x.IsClass)
-				.Where(x => !x.IsAbstract)
-				.Select(x => x);
+				.Where(x => !x.IsAbstract);
 
 
 			foreach (var messageType in messages)
@@ -42,25 +41,6 @@ namespace AmazingTwitchBot.Agent
 				services.AddSingleton(serviceProvider => (IChatMessageRule)ActivatorUtilities.CreateInstance(serviceProvider, messageType));
 			}
 			
-
-
-
-
-			//services.AddSingleton(messages);
-
-			// ---- this block could (should) be extracted out into a setup class
-			//services.AddSingleton<List<IChatMessageRule>>();
-			//services.AddSingleton<IChatMessageRule, HelloRule>();
-			//services.AddSingleton<IChatMessageRule, ProjectRule>();
-			//services.AddSingleton<IChatMessageRule, RustySpoonsRule>();
-			//services.AddSingleton<IChatMessageRule, SurlyYouCantBeSeriousRule>();
-			//services.AddSingleton<IChatMessageRule, SurlyDevClipRule>();
-			//services.AddSingleton<IChatMessageRule, DestructoPupRule>();
-			//services.AddSingleton<IChatMessageRule, InstagramRule>();
-			//services.AddSingleton<IChatMessageRule, TwitterRule>();
-			//services.AddSingleton<IChatMessageRule, BlogRule>();
-			// ------------------------------------------------
-
 
 			var serviceProvider = services.BuildServiceProvider();
 


### PR DESCRIPTION
Updated to using Reflection to get IChatMessage types for Dependancy Injection.
Instantiating classes use the  [ActivatorUtilities](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.activatorutilities?view=dotnet-plat-ext-3.1) class rather than [Activator ](https://docs.microsoft.com/en-us/dotnet/api/system.activator?view=netcore-3.1)class. [ActivatorUtilities](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.activatorutilities?view=dotnet-plat-ext-3.1) allows you to provide a service provider to resolve dependancies.

This is a pure Microsoft Solution not using 3rd party package. 

Have added this as an option to show there are multiple was to achive the same result. There is no right or wrong way  just personal preference on how to implement a feature.

Feel free to drop this pull request if this does not fit your pattern of work.